### PR TITLE
Add a note about troubleshooting a possible issue on MacOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,12 @@ This tool downloads all the files you have uploaded to FreeFeed.
 
 2. Generate the access token on FreeFeed using 👉 [**this link**](https://freefeed.net/settings/app-tokens/create?title=FrF%20Media%20Download&scopes=read-my-files) 👈. Paste the generated token into the _config.ini_ file.
 
-3. Run the `frf-media-download` in console/terminal.
+3. Run `frf-media-download` in console/terminal.
 
 The files will be downloaded to the "./results" folder.
 
 After a period of time you can run the program again to download the new files. Files that have already been downloaded will not be downloaded again.
+
+## Troubleshooting
+
+* If MacOS doesn't let you run the executable in Terminal because it is from an "unidentified developer", you might need to do `Open with... > Terminal` from Finder first and allow execution in a popup that appears.


### PR DESCRIPTION
This PR adds a note about dealing with an issue that is could occur when running the executable on MacOS. 

Read more:
* https://apple.stackexchange.com/questions/202169/how-can-i-open-an-app-from-an-unidentified-developer-without-using-the-gui
* https://www.howtogeek.com/205393/gatekeeper-101-why-your-mac-only-allows-apple-approved-software-by-default/